### PR TITLE
Fix router base path for GitHub Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === "development" ? "/" : "/invoice-magic-label/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure React Router with `basename` so it works from `/invoice-magic-label/`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c6bae146c832c92313d91d51e8f4d