### PR TITLE
Fix tablet category id

### DIFF
--- a/src/utils/categoryDetector.ts
+++ b/src/utils/categoryDetector.ts
@@ -334,7 +334,7 @@ const MPK_CATEGORIES: CategoryOption[] = [
     keywords: ['telefon', 'phone', 'mobile', 'smartphone']
   },
   {
-    id: 'equipment-tables',
+    id: 'equipment-tablet',
     name: 'Wyposażenie - Tablet',
     mpk: 'MPK870',
     group: '8/7',


### PR DESCRIPTION
## Summary
- fix a typo so `equipment-tablet` matches the category name

## Testing
- `npm run lint` *(fails: 21 errors, 7 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c635382e4832cbda1152f95c7524e