### PR TITLE
Fix toast hook effect dependency

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid repeated listener registration in `use-toast`

## Testing
- `npm run lint` *(fails: 21 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688c5f5f0688832c9344c0370b53ac5c