### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+
+      - uses: actions/deploy-pages@v2
+        id: deployment
+        with:
+          artifact_name: github-pages

--- a/README.md
+++ b/README.md
@@ -62,7 +62,16 @@ This project is built with:
 
 ## How can I deploy this project?
 
-Simply open [Lovable](https://lovable.dev/projects/f3541591-29c6-49df-ae28-c5766d85a790) and click on Share -> Publish.
+This repository ships with a GitHub Actions workflow that builds the site and
+deploys it to **GitHub Pages**. Any push to the `main` branch will trigger the
+workflow located at `.github/workflows/deploy.yml`.
+
+1. Make sure the repository's Pages settings are configured to use **GitHub
+   Actions** as the source.
+2. Push your changes to `main` or run the workflow manually from the Actions
+   tab.
+
+The deployed site is built from the contents of the generated `dist` directory.
 
 ## Can I connect a custom domain to my Lovable project?
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy to Pages
- document Pages deployment in README

## Testing
- `npm run build`
- `npm run lint` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c77703678832c9d57cbf0604447f5